### PR TITLE
Feat: better log file text output

### DIFF
--- a/android/xray/src/main/java/com/applicaster/xray/android/sinks/ADBSink.java
+++ b/android/xray/src/main/java/com/applicaster/xray/android/sinks/ADBSink.java
@@ -7,15 +7,15 @@ import androidx.annotation.NonNull;
 import com.applicaster.xray.core.Event;
 import com.applicaster.xray.core.ISink;
 import com.applicaster.xray.core.LogLevel;
+import com.applicaster.xray.core.formatting.event.ADBTextEventFormatter;
 import com.applicaster.xray.core.formatting.event.IEventFormatter;
-import com.applicaster.xray.core.formatting.event.PlainTextEventFormatter;
 
 /*
  Very basic adb output sink
  */
 public class ADBSink implements ISink {
 
-    private final IEventFormatter formatter = new PlainTextEventFormatter();
+    private final IEventFormatter formatter = new ADBTextEventFormatter();
 
     @Override
     public void log(@NonNull Event event) {

--- a/android/xray/src/main/java/com/applicaster/xray/core/formatting/event/PlainTextEventFormatter.java
+++ b/android/xray/src/main/java/com/applicaster/xray/core/formatting/event/PlainTextEventFormatter.java
@@ -1,19 +1,28 @@
 package com.applicaster.xray.core.formatting.event;
 
+import android.text.format.DateFormat;
+
 import androidx.annotation.NonNull;
 
 import com.applicaster.xray.core.Event;
+import com.applicaster.xray.core.LogLevel;
 
 import java.util.Map;
 
 public class PlainTextEventFormatter implements IEventFormatter {
 
-    // todo: set format string (ADB Sink does not need tag or time)
+    // todo: add format string option
 
     @NonNull
     @Override
     public String format(@NonNull Event event) {
-        StringBuilder sb = new StringBuilder(event.getMessage()).append("\n");
+        StringBuilder sb = new StringBuilder()
+                .append(DateFormat.format("yyyy-MM-dd HH:mm:ss", event.getTimestamp())).append(" ")
+                .append(LogLevel.fromLevel(event.getLevel()).name()).append(" ")
+                .append(event.getCategory()).append(" ")
+                .append(event.getSubsystem()).append(" ")
+                .append(event.getMessage())
+                .append("\n");
         Map<String, Object> data = event.getData();
         if(null != data && !data.isEmpty()) {
             sb.append("\n\tdata: ").append(data).append("\n");


### PR DESCRIPTION
Before, text output was using ADB formatter, that only needs to format message and context with data.
Now we have new formatter, that prints error level, category and subsystem in the text file.