### PR TITLE
Remove react native dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+node_modules

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "react": "16.11.0",
     "react-native": "0.62.2"
   },
-  "dependencies": {
+  "devDependencies": {
     "react": "16.11.0",
     "react-native": "0.62.2"
   },


### PR DESCRIPTION
This PR removes react native as a direct dependency and adds node_modules to gitignore