### PR TITLE
Add File JSON limitation features 

### DIFF
--- a/apple/XrayLogger/Sinks/FileJSON.swift
+++ b/apple/XrayLogger/Sinks/FileJSON.swift
@@ -10,9 +10,12 @@ import Foundation
 
 public class FileJSON: BaseSink, Storable {
     public private(set) var fileURL: URL?
-
+    public var maxLogFileSizeInMB: Double? = 20
+    public var deleteLogFileForNewAppVersion = true
     public var syncAfterEachWrite: Bool = false
     let fileManager = FileManager.default
+    let defaultsSuite: String = "Xray_FileJSON"
+    let defaultsAppVersionKey: String = "current_application_version"
 
     public init(fileName: String? = nil) {
         let fileName = fileName ?? "xray_file.json"
@@ -24,6 +27,7 @@ public class FileJSON: BaseSink, Storable {
         }
 
         super.init()
+        updateApplicationVersionInUserDefaults()
     }
 
     func getEvents() -> [[String: Any]] {
@@ -42,15 +46,17 @@ public class FileJSON: BaseSink, Storable {
 
     override public func log(event: Event) {
         guard let url = fileURL else { return }
-
+        deleteLogFileIfNeeded(url: url)
         let dict = event.toDictionary()
         var jsonEvents = getEvents()
         jsonEvents.append(dict)
+
         do {
             let data = try JSONSerialization.data(withJSONObject: jsonEvents,
                                                   options: [])
             try data.write(to: url,
                            options: [])
+
         } catch {
             print(error)
         }
@@ -61,5 +67,46 @@ public class FileJSON: BaseSink, Storable {
 
         let result = FileManagerHelper.deleteLogFile(url: url)
         return result
+    }
+
+    private func deleteLogFileIfNeeded(url: URL) {
+        if isFileSizeLimitRiched(url: url) == true {
+            _ = deleteLogFile()
+        }
+    }
+
+    public func isFileSizeLimitRiched(url: URL) -> Bool {
+        guard let maxLogFileSizeInMB = maxLogFileSizeInMB,
+            let fileSizeInMB = FileManagerHelper.fileSizeInMB(forURL: url),
+            fileSizeInMB > maxLogFileSizeInMB else {
+            return false
+        }
+        return true
+    }
+
+    public func applicationHasNewVersion() -> String? {
+        guard
+            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        else {
+            return nil
+        }
+
+        let currentApplicationVersion = UserDefaults(suiteName: defaultsSuite)?.string(forKey: defaultsAppVersionKey)
+
+        return currentApplicationVersion != appVersion ? appVersion : nil
+    }
+
+    public func updateApplicationVersionInUserDefaults() {
+        guard let newApplicationVersion = applicationHasNewVersion()
+        else {
+            return
+        }
+
+        if deleteLogFileForNewAppVersion == true {
+            _ = deleteLogFile()
+        }
+
+        UserDefaults(suiteName: defaultsSuite)?.setValue(newApplicationVersion,
+                                                         forKey: defaultsAppVersionKey)
     }
 }

--- a/apple/XrayLogger/Sinks/FileJSON.swift
+++ b/apple/XrayLogger/Sinks/FileJSON.swift
@@ -48,6 +48,9 @@ public class FileJSON: BaseSink, Storable {
         guard let url = fileURL else { return }
         deleteLogFileIfNeeded(url: url)
         let dict = event.toDictionary()
+        guard JSONSerialization.isValidJSONObject(dict) else {
+            return
+        }
         var jsonEvents = getEvents()
         jsonEvents.append(dict)
 

--- a/apple/XrayLogger/Sinks/FileJSON.swift
+++ b/apple/XrayLogger/Sinks/FileJSON.swift
@@ -78,7 +78,7 @@ public class FileJSON: BaseSink, Storable {
         }
     }
 
-    public func isFileSizeLimitRiched(url: URL) -> Bool {
+    private func isFileSizeLimitRiched(url: URL) -> Bool {
         guard let maxLogFileSizeInMB = maxLogFileSizeInMB,
             let fileSizeInMB = FileManagerHelper.fileSizeInMB(forURL: url),
             fileSizeInMB > maxLogFileSizeInMB else {
@@ -87,7 +87,7 @@ public class FileJSON: BaseSink, Storable {
         return true
     }
 
-    public func applicationHasNewVersion() -> String? {
+    private func applicationHasNewVersion() -> String? {
         guard
             let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         else {
@@ -99,7 +99,7 @@ public class FileJSON: BaseSink, Storable {
         return currentApplicationVersion != appVersion ? appVersion : nil
     }
 
-    public func updateApplicationVersionInUserDefaults() {
+    private func updateApplicationVersionInUserDefaults() {
         guard let newApplicationVersion = applicationHasNewVersion()
         else {
             return

--- a/apple/XrayLogger/Utils/FileManagerHelper.swift
+++ b/apple/XrayLogger/Utils/FileManagerHelper.swift
@@ -82,4 +82,19 @@ class FileManagerHelper {
             return false
         }
     }
+
+    public class func fileSizeInMB(forURL url: URL) -> Double? {
+        let mbInBytes = 0.000001
+        do {
+            // return [FileAttributeKey : Any]
+            let attr = try FileManager.default.attributesOfItem(atPath: url.path)
+            if let fileSize = attr[FileAttributeKey.size] as? Double {
+                return fileSize * mbInBytes
+            }
+
+        } catch {
+            print("Error: \(error)")
+        }
+        return nil
+    }
 }


### PR DESCRIPTION
- Add option to set max size of the file `maxLogFileSizeInMB`, if size limit is bigger file can be deleted. If max size is `nil` limits disabled. `Default:20mb`
- Add option to erase file if new app version was installed `deleteLogFileForNewAppVersion` `default: true`
- Add safe check if event can not be transferred to json, ignore log