### PR TITLE
feat: Generate separate log files and unite if needed

### DIFF
--- a/apple/Extensions/Reporter/Reporter.swift
+++ b/apple/Extensions/Reporter/Reporter.swift
@@ -11,6 +11,7 @@ import MessageUI
 
 public protocol StorableSinkDelegate {
     func getLogFileUrl(_ completion: ((URL?) -> ())?)
+    func deleteLogFile()
 }
 
 public class Reporter {
@@ -39,7 +40,10 @@ public class Reporter {
                 sharedInstance.email.requestSendEmail(emails: sharedEmails,
                                                       sharedFileURL: url,
                                                       contexts: sharedContexts,
-                                                      attachments: nil)
+                                                      attachments: nil,
+                                                      completion: {
+                                                        sharedLogFileSinkDelegate?.deleteLogFile()
+                                                      })
             }
         })
         
@@ -54,6 +58,9 @@ public class Reporter {
         sharedInstance.email.requestSendEmail(emails: emails,
                                               sharedFileURL: nil,
                                               contexts: sharedContexts,
-                                              attachments: attachments)
+                                              attachments: attachments,
+                                              completion: {
+                                                sharedLogFileSinkDelegate?.deleteLogFile()
+                                              })
     }
 }

--- a/apple/Extensions/Reporter/Reporter.swift
+++ b/apple/Extensions/Reporter/Reporter.swift
@@ -9,18 +9,22 @@
 import Foundation
 import MessageUI
 
+public protocol StorableSinkDelegate {
+    func getLogFileUrl(_ completion: ((URL?) -> ())?)
+}
+
 public class Reporter {
     public static let sharedInstance = Reporter()
     public private(set) static var sharedEmails: [String]?
-    public private(set) static var sharedFileURL: URL?
+    public private(set) static var sharedLogFileSinkDelegate: StorableSinkDelegate?
     public private(set) static var sharedContexts: [String: Any]?
     var email = Email()
 
     public static func setDefaultData(emails: [String],
-                                      url: URL?,
+                                      logFileSinkDelegate: StorableSinkDelegate?,
                                       contexts: [String: Any]?) {
         sharedEmails = emails
-        sharedFileURL = url
+        sharedLogFileSinkDelegate = logFileSinkDelegate
         sharedContexts = contexts
     }
 
@@ -29,10 +33,16 @@ public class Reporter {
             print("Cannot send email, at least one sender must be defined")
             return
         }
-        sharedInstance.email.requestSendEmail(emails: sharedEmails,
-                                              sharedFileURL: sharedFileURL,
-                                              contexts: sharedContexts,
-                                              attachments: nil)
+        
+        sharedLogFileSinkDelegate?.getLogFileUrl({ (url) in
+            if let url = url {
+                sharedInstance.email.requestSendEmail(emails: sharedEmails,
+                                                      sharedFileURL: url,
+                                                      contexts: sharedContexts,
+                                                      attachments: nil)
+            }
+        })
+        
     }
 
     public static func requestSendCustomEmail(attachments: [EmailAttachment]? = nil) {

--- a/apple/XrayLogger/Core/Protocols/SinkExtensions/Storable.swift
+++ b/apple/XrayLogger/Core/Protocols/SinkExtensions/Storable.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public protocol Storable {
-    var fileURL:URL? { get }
+    func generateLogsToSingleFileUrl(_ completion: ((URL?) -> ())?)
 }

--- a/apple/XrayLogger/Core/Protocols/SinkExtensions/Storable.swift
+++ b/apple/XrayLogger/Core/Protocols/SinkExtensions/Storable.swift
@@ -10,4 +10,5 @@ import Foundation
 
 public protocol Storable {
     func generateLogsToSingleFileUrl(_ completion: ((URL?) -> ())?)
+    func deleteSingleFileUrl()
 }

--- a/apple/XrayLogger/Sinks/BaseSink.swift
+++ b/apple/XrayLogger/Sinks/BaseSink.swift
@@ -23,7 +23,7 @@ public class BaseSink: NSObject, SinkProtocol {
     public func log(event: Event) {
         // Shoulds be implemented on top lovel
     }
-
+    
     public static func == (lhs: BaseSink, rhs: BaseSink) -> Bool {
         return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }

--- a/apple/XrayLogger/Sinks/FileJSON.swift
+++ b/apple/XrayLogger/Sinks/FileJSON.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public class FileJSON: BaseSink {
     fileprivate var logsFolderURL: URL?
+    fileprivate let singleLogsFileName = "XrayJsonLogs.json"
     public var maxLogFileSizeInMB: Double? = 20
     public var deleteLogsFolderContentForNewAppVersion = true
     public var syncAfterEachWrite: Bool = false
@@ -131,7 +132,6 @@ public class FileJSON: BaseSink {
 
 extension FileJSON: Storable {
     public func generateLogsToSingleFileUrl(_ completion: ((URL?) -> Void)?) {
-        let singleLogsFileName = "XrayJsonLogs.json"
 
         guard let logsFolderURL = logsFolderURL,
             let documentsFolder = fileManager.urls(for: .documentDirectory,
@@ -164,6 +164,16 @@ extension FileJSON: Storable {
         }
 
         completion?(success ? singleLogsFileUrl : nil)
+    }
+    
+    public func deleteSingleFileUrl() {
+        guard let documentsFolder = fileManager.urls(for: .documentDirectory,
+                                                     in: .userDomainMask).first else {
+            return
+        }
+        let singleLogsFileUrl = documentsFolder.appendingPathComponent(singleLogsFileName,
+                                                                       isDirectory: false)
+        _ = FileManagerHelper.deleteLogFile(url: singleLogsFileUrl)
     }
 
     fileprivate func getEvent(fromFile fileUrl: URL) -> [String: Any] {

--- a/apple/XrayLogger/Sinks/FileLog.swift
+++ b/apple/XrayLogger/Sinks/FileLog.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public class FileLog: BaseSink {
     fileprivate var logsFolderURL: URL?
+    fileprivate let singleLogsFileName = "XrayTxtLogs.txt"
     let fileManager = FileManager.default
 
     public init(folderName: String? = nil) {
@@ -43,7 +44,7 @@ public class FileLog: BaseSink {
                                          url: fileUrl,
                                          sync: false)
     }
-    
+
     public func deleteLogsFolderContent(at path: URL) {
         guard let filePaths = try? fileManager.contentsOfDirectory(at: path,
                                                                    includingPropertiesForKeys: nil,
@@ -57,10 +58,8 @@ public class FileLog: BaseSink {
     }
 }
 
-extension FileLog : Storable {
+extension FileLog: Storable {
     public func generateLogsToSingleFileUrl(_ completion: ((URL?) -> Void)?) {
-        let singleLogsFileName = "XrayTxtLogs.txt"
-
         guard let logsFolderURL = logsFolderURL,
             let documentsFolder = fileManager.urls(for: .documentDirectory,
                                                    in: .userDomainMask).first,
@@ -84,6 +83,16 @@ extension FileLog : Storable {
                                                    sync: false)
 
         completion?(success ? singleLogsFileUrl : nil)
+    }
+
+    public func deleteSingleFileUrl() {
+        guard let documentsFolder = fileManager.urls(for: .documentDirectory,
+                                                     in: .userDomainMask).first else {
+            return
+        }
+        let singleLogsFileUrl = documentsFolder.appendingPathComponent(singleLogsFileName,
+                                                                       isDirectory: false)
+        _ = FileManagerHelper.deleteLogFile(url: singleLogsFileUrl)
     }
 
     fileprivate func getEventLine(fromFile fileUrl: URL) -> String {

--- a/apple/XrayLogger/Sinks/FileLog.swift
+++ b/apple/XrayLogger/Sinks/FileLog.swift
@@ -1,5 +1,5 @@
 //
-//  Console.swift
+//  FileLog.swift
 //  xray
 //
 //  Created by Anton Kononenko on 7/17/20.
@@ -8,38 +8,92 @@
 
 import Foundation
 
-public class FileLog: BaseSink, Storable {
-    public private(set) var fileURL: URL?
-    public var syncAfterEachWrite: Bool = false
+public class FileLog: BaseSink {
+    fileprivate var logsFolderURL: URL?
     let fileManager = FileManager.default
 
-    public init(fileName: String? = nil) {
-        let fileName = fileName ?? "xray_file_log.txt"
+    public init(folderName: String? = nil) {
+        let folderName = folderName ?? "XrayTxtLogs"
 
-        // sharedPublicDirectory
         if let url = fileManager.urls(for: .documentDirectory,
                                       in: .userDomainMask).first {
-            fileURL = url.appendingPathComponent(fileName,
-                                                 isDirectory: false)
+            let dataPath = url.appendingPathComponent(folderName)
+            if !fileManager.fileExists(atPath: dataPath.absoluteString) {
+                do {
+                    try fileManager.createDirectory(atPath: dataPath.path,
+                                                    withIntermediateDirectories: true,
+                                                    attributes: nil)
+                    logsFolderURL = dataPath
+                } catch {}
+            }
         }
 
         super.init()
     }
 
     override public func log(event: Event) {
-        guard let url = fileURL else { return }
+        guard let logsFolderURL = logsFolderURL else {
+            return
+        }
 
+        let fileUrl = logsFolderURL.appendingPathComponent("\(UUID().uuidString).txt")
         let message = formatter?.format(event: event) ?? event.message
 
         _ = FileManagerHelper.saveToFile(str: message,
-                                         url: url,
-                                         sync: syncAfterEachWrite)
+                                         url: fileUrl,
+                                         sync: false)
+    }
+    
+    public func deleteLogsFolderContent(at path: URL) {
+        guard let filePaths = try? fileManager.contentsOfDirectory(at: path,
+                                                                   includingPropertiesForKeys: nil,
+                                                                   options: []) else {
+            return
+        }
+
+        for filePath in filePaths {
+            try? fileManager.removeItem(at: filePath)
+        }
+    }
+}
+
+extension FileLog : Storable {
+    public func generateLogsToSingleFileUrl(_ completion: ((URL?) -> Void)?) {
+        let singleLogsFileName = "XrayTxtLogs.txt"
+
+        guard let logsFolderURL = logsFolderURL,
+            let documentsFolder = fileManager.urls(for: .documentDirectory,
+                                                   in: .userDomainMask).first,
+            let filePaths = try? fileManager.contentsOfDirectory(at: logsFolderURL,
+                                                                 includingPropertiesForKeys: nil,
+                                                                 options: []) else {
+            completion?(nil)
+            return
+        }
+
+        var events: [String] = []
+        for filePath in filePaths {
+            let fileEvent = getEventLine(fromFile: filePath)
+            events.append(fileEvent)
+        }
+        let eventsStringRepresentation = events.joined(separator: "\n")
+        let singleLogsFileUrl = documentsFolder.appendingPathComponent(singleLogsFileName,
+                                                                       isDirectory: false)
+        let success = FileManagerHelper.saveToFile(str: eventsStringRepresentation,
+                                                   url: singleLogsFileUrl,
+                                                   sync: false)
+
+        completion?(success ? singleLogsFileUrl : nil)
     }
 
-    public func deleteLogFile() -> Bool {
-        guard let url = fileURL else { return true }
-
-        let result = FileManagerHelper.deleteLogFile(url: url)
-        return result
+    fileprivate func getEventLine(fromFile fileUrl: URL) -> String {
+        do {
+            let data = try Data(contentsOf: fileUrl,
+                                options: .mappedIfSafe)
+            return String(data: data, encoding: String.Encoding.utf8) ?? ""
+        } catch {
+            print(error.localizedDescription)
+            return ""
+        }
     }
 }


### PR DESCRIPTION
Generate separate log files and unite if needed 
instead of saving to the single file as read/write operations crashing the app