### PR TITLE
feat: keep expanded items state on scroll and update

### DIFF
--- a/android/xray-ui/src/main/res/values/strings.xml
+++ b/android/xray-ui/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="show_notification">Show notification</string>
     <string name="shortcut_access">Shortcut access</string>
     <string name="file_log_level">File log level</string>
+    <string name="xray_lbl_tap_for_details">Tap for details...</string>
 
     <!-- https://stackoverflow.com/a/52308875 -->
     <attr name="sink_name" format="string|reference" />


### PR DESCRIPTION
Resolves #41.
Now expanded items are not collapsed on scroll or update.