### PR TITLE
feat: allow content provider share from any app path

### DIFF
--- a/android/xray-crashreporter/src/main/res/xml/report_provider_paths.xml
+++ b/android/xray-crashreporter/src/main/res/xml/report_provider_paths.xml
@@ -2,5 +2,14 @@
 <paths>
     <files-path
         name="share"
-        path="."/>
+        path="." />
+    <external-files-path
+        name="external"
+        path="." />
+    <cache-path
+        name="cache"
+        path="." />
+    <external-cache-path
+        name="external_cache"
+        path="." />
 </paths>


### PR DESCRIPTION
In some cases we want to be able to share files we save in internal cache of external files directory.