### PR TITLE
feat: can setup default memory events list level from xml

### DIFF
--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -28,7 +28,8 @@
             android:name="com.applicaster.xray.ui.fragments.EventLogFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:sink_name="memory_sink" />
+            app:sink_name="memory_sink"
+            app:default_level="info"/>
 
         <fragment
             android:id="@+id/default_logfile_fragment"

--- a/android/xray-ui/src/main/java/com/applicaster/xray/ui/fragments/EventLogFragment.kt
+++ b/android/xray-ui/src/main/java/com/applicaster/xray/ui/fragments/EventLogFragment.kt
@@ -24,12 +24,18 @@ import com.applicaster.xray.ui.utility.FilteredEventList
 class EventLogFragment : Fragment() {
 
     private var inMemorySinkName: String? = null
+    private var defaultLevel: Int = LogLevel.info.level
 
     override fun onInflate(context: Context, attrs: AttributeSet, savedInstanceState: Bundle?) {
         super.onInflate(context, attrs, savedInstanceState)
         val ta = context.obtainStyledAttributes(attrs, R.styleable.EventLogFragment_MembersInjector)
         if (ta.hasValue(R.styleable.EventLogFragment_MembersInjector_sink_name)) {
             inMemorySinkName = ta.getString(R.styleable.EventLogFragment_MembersInjector_sink_name)
+        }
+        if(ta.hasValue(R.styleable.EventLogFragment_MembersInjector_default_level)){
+            ta.getString(R.styleable.EventLogFragment_MembersInjector_default_level)?.toIntOrNull()?.let {
+                defaultLevel = LogLevel.fromLevel(it).level
+            }
         }
         ta.recycle()
     }
@@ -66,7 +72,7 @@ class EventLogFragment : Fragment() {
                         android.R.layout.simple_list_item_1,
                         LogLevel.values()
                 )
-                setSelection(LogLevel.info.level)
+                setSelection(defaultLevel)
                 onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
                     override fun onNothingSelected(parent: AdapterView<*>?) {
                     }

--- a/android/xray-ui/src/main/res/values/strings.xml
+++ b/android/xray-ui/src/main/res/values/strings.xml
@@ -8,13 +8,22 @@
     <string name="show_notification">Show notification</string>
     <string name="shortcut_access">Shortcut access</string>
     <string name="file_log_level">File log level</string>
-    <string name="xray_lbl_tap_for_details">Tap for details...</string>
+    <string name="xray_lbl_tap_for_details">Tap for details…</string>
 
     <!-- https://stackoverflow.com/a/52308875 -->
     <attr name="sink_name" format="string|reference" />
     <attr name="file_name" format="string|reference" />
+    <!-- Numbers are values of LogLevel -->
+    <attr name="default_level" format="enum|reference" >
+        <enum name="verbose" value="0" />
+        <enum name="debug" value="1" />
+        <enum name="info" value="2" />
+        <enum name="warning" value="3" />
+        <enum name="error" value="4" />
+    </attr>
     <declare-styleable name="EventLogFragment_MembersInjector">
         <attr name="sink_name" />
+        <attr name="default_level" />
     </declare-styleable>
     <declare-styleable name="FileLogFragment_MembersInjector">
         <attr name="file_name" />


### PR DESCRIPTION
New xml attribute for EventLogFragment:
app:default_level
```
        <fragment
            android:id="@+id/fragment"
            android:name="com.applicaster.xray.ui.fragments.EventLogFragment"
            android:layout_width="match_parent"
            android:layout_height="match_parent"
            app:sink_name="memory_sink"
            app:default_level="info"/>
```